### PR TITLE
Feat: common status constant

### DIFF
--- a/jsconfig.json
+++ b/jsconfig.json
@@ -5,7 +5,8 @@
       "@features/*": ["./src/features/*"],
       "@pages/*": ["./src/pages/*"],
       "@config/*": ["./src/config/*"],
-      "@services/*": ["./src/services/*"]
+      "@services/*": ["./src/services/*"],
+      "@common/*": ["./src/common/*"]
     }
   }
 }

--- a/src/common/constants/index.js
+++ b/src/common/constants/index.js
@@ -1,0 +1,1 @@
+export * from "./status";

--- a/src/common/constants/status.js
+++ b/src/common/constants/status.js
@@ -1,0 +1,6 @@
+export const STATUS = {
+  IDLE: "idle",
+  LOADING: "loading",
+  SUCCEEDED: "succeeded",
+  FAILED: "failed",
+};

--- a/vite.config.js
+++ b/vite.config.js
@@ -15,6 +15,7 @@ export default defineConfig({
       "@pages": path.resolve(__dirname, "./src/pages"),
       "@config": path.resolve(__dirname, "./src/config"),
       "@services": path.resolve(__dirname, "./src/services"),
+      "@common": path.resolve(__dirname, "./src/common"),
     },
   },
 });


### PR DESCRIPTION
##[Feat] common 디텍토리의 constants 폴더에 status.js 추가

### 변경 사안
- `common/constants` 폴더 추가
- status에 사용되는 상수들을 `common/constants/status.js` 로 분리
- `@common` 경로 별칭 추가

### 이유
- 상수의 분리: 상수의 사용에 있어서 휴먼에러를 방지하기 위함
- 폴더 및 경로 추가: 상수의 사용에 있어서 재사용성을 증가시키기 위함