### PR TITLE
Feat: global styled components

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     "react-dom": "^19.0.0",
     "react-redux": "^9.2.0",
     "react-router-dom": "^7.2.0",
-    "styled-components": "^6.1.15"
+    "styled-components": "^6.1.15",
+    "styled-normalize": "^8.1.1"
   },
   "devDependencies": {
     "@eslint/js": "^9.21.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -29,6 +29,9 @@ importers:
       styled-components:
         specifier: ^6.1.15
         version: 6.1.15(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      styled-normalize:
+        specifier: ^8.1.1
+        version: 8.1.1(styled-components@6.1.15(react-dom@19.0.0(react@19.0.0))(react@19.0.0))
     devDependencies:
       '@eslint/js':
         specifier: ^9.21.0
@@ -1288,6 +1291,11 @@ packages:
     peerDependencies:
       react: '>= 16.8.0'
       react-dom: '>= 16.8.0'
+
+  styled-normalize@8.1.1:
+    resolution: {integrity: sha512-Nd6iLDjKuxotRHSewe+qFqvw33WxIotbjZ3YkC8802manACBchUIb7vJt/C8ylDrO5850HmlnQTApwJLuN9sug==}
+    peerDependencies:
+      styled-components: ^4.0.0 || ^5.0.0 || ^6.0.0
 
   stylis@4.3.2:
     resolution: {integrity: sha512-bhtUjWd/z6ltJiQwg0dUfxEJ+W+jdqQd8TbWLWyeIJHlnsqmGLRFFd8e5mA0AZi/zx90smXRlN66YMTcaSFifg==}
@@ -2607,6 +2615,10 @@ snapshots:
       shallowequal: 1.1.0
       stylis: 4.3.2
       tslib: 2.6.2
+
+  styled-normalize@8.1.1(styled-components@6.1.15(react-dom@19.0.0(react@19.0.0))(react@19.0.0)):
+    dependencies:
+      styled-components: 6.1.15(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
 
   stylis@4.3.2: {}
 

--- a/src/app/main.jsx
+++ b/src/app/main.jsx
@@ -1,3 +1,4 @@
+import GlobalStyle from "@common/styles/globalStyles.js";
 import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
 import { Provider as ReduxProvider } from "react-redux";
@@ -9,6 +10,7 @@ createRoot(document.getElementById("root")).render(
   <StrictMode>
     <ReduxProvider store={store}>
       <BrowserRouter>
+        <GlobalStyle />
         <App />
       </BrowserRouter>
     </ReduxProvider>

--- a/src/common/styles/globalStyles.js
+++ b/src/common/styles/globalStyles.js
@@ -1,0 +1,14 @@
+import { createGlobalStyle } from "styled-components";
+import normalize from "styled-normalize";
+
+const GlobalStyle = createGlobalStyle`
+  ${normalize} // Normalize CSS 적용
+
+  *,
+  *::before,
+  *::after {
+    box-sizing: border-box; // 보다 정확한 높이와 너비를 위한 전역 box-sizing 설정
+  }
+`;
+
+export default GlobalStyle;


### PR DESCRIPTION
## [feat] 전역 스타일 추가

### 변경사항 요약
- styled-normalize 설치
- GlobalStyle 컴포넌트 작성 및 적용

### 구현 설명
- css reset 방식보다는 normalize하는 방식이 신경써야 할 부분이 줄어든다고 생각했기 때문에, normalize 방식을 택했습니다.
- box 바깥으로 요소가 벗어나는 문제를 막기 위해, 전역 스타일로 box-sizing을 border-box 기준으로 설정했습니다.