### PR TITLE
refactor: date-fns를 기반으로 useEventTimeInput 개선

### DIFF
--- a/src/features/events/hooks/useEventTimeInput.js
+++ b/src/features/events/hooks/useEventTimeInput.js
@@ -1,3 +1,4 @@
+import { isErr, isOk, Ok } from "@common/utils";
 import { isAfter, isBefore, isSameDay } from "date-fns";
 import { useMemo, useState } from "react";
 import {
@@ -7,98 +8,131 @@ import {
   parseAndAdjustTimeToHour,
 } from "../utils/timeUtils";
 
-const initialConstraints = { min: null, max: null };
+const initialConstraints = Ok({ min: null, max: null }); // Result 객체로 관리하기 위함
 
 export const useEventTimeInput = (
   initialStartTime = "",
   initialEndTime = ""
 ) => {
-  const [startTime, setStartTime] = useState(
-    parseAndAdjustTimeToHour(initialStartTime)
-  );
-  const [endTime, setEndTime] = useState(
-    parseAndAdjustTimeToHour(initialEndTime)
-  );
+  // 시간은 Result 확인 후 value(Date객체)값 혹은 null로 관리
+  const [startTime, setStartTime] = useState(() => {
+    const result = parseAndAdjustTimeToHour(initialStartTime);
+    return isOk(result) ? result.value : null;
+  });
+  const [endTime, setEndTime] = useState(() => {
+    const result = parseAndAdjustTimeToHour(initialEndTime);
+    return isOk(result) ? result.value : null;
+  });
+  // 제약조건 또한 Result 객체로 관리
   const [startTimeConstraints, setStartTimeConstraints] =
     useState(initialConstraints);
   const [endTimeConstraints, setEndTimeConstraints] =
     useState(initialConstraints);
 
-  const startTimeLocalString = useMemo(
-    () => formatDateToLocalDateTimeString(startTime),
-    [startTime]
-  );
-  const endTimeLocalString = useMemo(() =>
-    formatDateToLocalDateTimeString(endTime, [endTime])
-  );
-  const startTimeConstraintStrings = useMemo(
-    () => ({
-      min: formatDateToLocalDateTimeString(startTimeConstraints.min),
-      max: formatDateToLocalDateTimeString(startTimeConstraints.max),
-    }),
-    [startTimeConstraints]
-  );
-  const endTimeConstraintStrings = useMemo(
-    () => ({
-      min: formatDateToLocalDateTimeString(endTimeConstraints.min),
-      max: formatDateToLocalDateTimeString(endTimeConstraints.max),
-    }),
-    [endTimeConstraints]
-  );
+  // Input 에 표시될 시간 문자열
+  const startTimeLocalString = useMemo(() => {
+    const result = formatDateToLocalDateTimeString(startTime);
+    return isOk(result) ? result.value : "";
+  }, [startTime]);
+  const endTimeLocalString = useMemo(() => {
+    const result = formatDateToLocalDateTimeString(endTime);
+    return isOk(result) ? result.value : "";
+  }, [endTime]);
+
+  // 제약 조건 문자열 (Input min/max 속성용)
+  const startTimeConstraintStrings = useMemo(() => {
+    if (isErr(startTimeConstraints)) {
+      return { min: "", max: "" };
+    }
+    const constraints = startTimeConstraints.value;
+    const minResult = formatDateToLocalDateTimeString(constraints.min);
+    const maxResult = formatDateToLocalDateTimeString(constraints.max);
+    return {
+      min: isOk(minResult) ? minResult.value : "",
+      max: isOk(maxResult) ? maxResult.value : "",
+    };
+  }, [startTimeConstraints]);
+  const endTimeConstraintStrings = useMemo(() => {
+    if (isErr(endTimeConstraints)) {
+      return { min: "", max: "" };
+    }
+    const constraints = endTimeConstraints.value;
+    const minResult = formatDateToLocalDateTimeString(constraints.min);
+    const maxResult = formatDateToLocalDateTimeString(constraints.max);
+    return {
+      min: isOk(minResult) ? minResult.value : "",
+      max: isOk(maxResult) ? maxResult.value : "",
+    };
+  }, [endTimeConstraints]);
 
   const handleStartTimeChange = (e) => {
-    const newStartTime = parseAndAdjustTimeToHour(e.target.value);
-    setStartTime(newStartTime);
+    const parseResult = parseAndAdjustTimeToHour(e.target.value);
 
-    if (!newStartTime) {
-      // startTime 입력 초기화 시, 시간 제약조건 모두 초기화
+    if (isErr(parseResult)) {
+      // 에러 발생시 (ex: 입력 초기화) 시간 제약조건 모두 초기화
+      setStartTime(null);
       setStartTimeConstraints(initialConstraints);
       setEndTimeConstraints(initialConstraints);
       if (endTime) {
-        // endTime 있을 경우, 시작시간 제약조건 다시 설정
-        const constraints = calculateStartTimeConstraints(endTime);
-        setStartTimeConstraints(constraints);
+        // endTime이 있을 경우, 시작시간 제약조건 다시 설정
+        const constraintsResult = calculateStartTimeConstraints(endTime);
+        setStartTimeConstraints(constraintsResult);
       }
       return;
     }
-    // startTime 입력 시, 종료시간 제약조건 설정
-    const constraints = calculateEndTimeConstraints(newStartTime);
-    setEndTimeConstraints(constraints);
 
-    // 종료 시간 초기화 로직
-    if (
-      endTime &&
-      constraints.min &&
-      (isBefore(endTime, constraints.min) || !isSameDay(endTime, newStartTime))
-    ) {
-      setEndTime(null);
+    const newStartTime = parseResult.value;
+    setStartTime(newStartTime);
+
+    const constraintsResult = calculateEndTimeConstraints(newStartTime);
+    setEndTimeConstraints(constraintsResult);
+
+    // 종료시간 초기화 로직
+    if (isOk(constraintsResult)) { // 제약 조건 계산 성공 시에만 비교
+      const constraints = constraintsResult.value;
+      if (
+        endTime &&
+        constraints.min &&
+        (isBefore(endTime, constraints.min) ||
+          !isSameDay(endTime, newStartTime))
+      ) {
+        setEndTime(null);
+      }
     }
   };
 
   const handleEndTimeChange = (e) => {
-    const newEndDate = parseAndAdjustTimeToHour(e.target.value);
-    setEndTime(newEndDate);
+    const parseResult = parseAndAdjustTimeToHour(e.target.value);
 
-    if (!newEndDate) {
+    if (isErr(parseResult)) {
+      setEndTime(null);
       setStartTimeConstraints(initialConstraints);
       setEndTimeConstraints(initialConstraints);
       if (startTime) {
-        const constraints = calculateEndTimeConstraints(startTime);
-        setEndTimeConstraints(constraints);
+        // startTime이 있을 경우, 종료시간 제약조건 다시 설정
+        const constraintsResult = calculateEndTimeConstraints(startTime);
+        setEndTimeConstraints(constraintsResult);
       }
       return;
     }
-    // endTime 입력 시, 시작시간 제약조건 설정
-    const constraints = calculateStartTimeConstraints(newEndDate);
-    setStartTimeConstraints(constraints);
 
-    // 시작 시간 초기화 로직
-    if (
-      startTime &&
-      constraints.max &&
-      (isAfter(startTime, constraints.max) || !isSameDay(startTime, newEndDate))
-    ) {
-      setStartTime(null);
+    const newEndTime = parseResult.value;
+    setEndTime(newEndTime);
+
+    const constraintsResult = calculateStartTimeConstraints(newEndTime);
+    setStartTimeConstraints(constraintsResult);
+
+    // 시작시간 초기화 로직
+    if (isOk(constraintsResult)) {
+      const constraints = constraintsResult.value;
+      if (
+        startTime &&
+        constraints.max &&
+        (isAfter(startTime, constraints.max) ||
+          !isSameDay(startTime, newEndTime))
+      ) {
+        setStartTime(null);
+      }
     }
   };
 


### PR DESCRIPTION
### [fefactor] date-fns를 기반으로 useEventTimeInput 개선
###  변경사안 요약
- native Date를 이용하는 방식에서 date-fns를 활용하는 방식으로 개선
- 상태 관리 변경: 내부 시간(startTime, endTime)을 날짜시간문자열에서 Date 객체(혹은 null)를 이용하는 방식으로 변경
- 반환 값 변경: 입력에 필요한 문자열들(startTimeLocalString, startTimeConstraintStrings 등)을 useMemo를 이용하여 필요한 값만 계산해서 반환할 수 있도록 적용
### 변경이유
- 코드의 안정성과 정확성을 높이기 위해 date-fns 도입
- date-fns 도입에 적합하게 상태를 Date 객체로 변경
- 최종 반환값에 맞추기 위해 useMemo를 활용 (추후 성능 최적화에 기여)