### PR TITLE
feat: resetEventStatus 액션 추가

### DIFF
--- a/src/features/events/slices/eventSlice.js
+++ b/src/features/events/slices/eventSlice.js
@@ -52,11 +52,17 @@ const setFailedStatus = (state, action) => {
   state.status = STATUS.FAILED;
   state.error = action.error.message;
 };
+const setIdleStatus = (state) => {
+  state.status = STATUS.IDLE;
+  state.error = null;
+};
 
 const eventSlice = createSlice({
   name: "events",
   initialState,
-  reducers: {},
+  reducers: {
+    resetEventStatus: setIdleStatus,
+  },
   extraReducers: (builder) => {
     builder
       // fetchEvents 액션 처리
@@ -88,4 +94,5 @@ const eventSlice = createSlice({
   },
 });
 
+export const { resetEventStatus } = eventSlice.actions;
 export default eventSlice.reducer;


### PR DESCRIPTION
## [feat]  resetEventStatus 액션 추가
### 변경사항 요약
- `resetEventStatus` 액션 추가
- `setIdleStatus` 헬퍼 함수 추출
### 변경 이유
- 이벤트 생성/수정/삭제 후 또는 컴포넌트 unmount 시, status 및 error 상태를 초기화하여 불필요한 UI 상태(ex. 이전 에러 메시지 표시)가 유지되는 것을 방지하고 상태 관리의 예측 가능성을 높이기 위함