### PR TITLE
Feat/calendar view

### DIFF
--- a/src/features/calendar/components/CalendarGrid/CalendarEvent.jsx
+++ b/src/features/calendar/components/CalendarGrid/CalendarEvent.jsx
@@ -1,0 +1,85 @@
+import { logger } from "@common/utils";
+import { HOUR_HEIGHT } from "@features/calendar/constants/calendarConstants";
+import { useNavigate } from "react-router-dom";
+import styled from "styled-components";
+
+// 개별 이벤트 스타일
+const EventWrapper = styled.div.attrs((props) => ({
+  style: {
+    top: `${props.$top || 0}px`,
+    height: `${props.$height || HOUR_HEIGHT}px`,
+    left: `${props.$left || "0%"}`,
+    width: `${props.$width || "100%"}`,
+  },
+}))`
+  position: absolute;
+  background-color: #e9f5ff;
+  border: 1px solid #aed6f1;
+  border-left: 3px solid #3498db;
+  border-radius: 4px;
+  padding: 3px 6px;
+  font-size: 0.75rem;
+  color: #2c3e50;
+  overflow: hidden;
+  cursor: pointer;
+  transition: background-color 0.2s ease;
+
+  &:hover {
+    background-color: #d4eaff;
+  }
+`;
+
+const EventContent = styled.div`
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+`;
+
+/**
+ * Calendar Event Component
+ * 이벤트 데이터를 받아 시각적으로 표시하고 클릭 이벤트를 처리합니다
+ * 위치(top, heigth, left, width)는 props로 전달 받습니다
+ *
+ * @param {object} props
+ * @param {object} props.event - 이벤트 데이터 객체
+ * @param {number} [props.$top] - 계산된 top 위치 (px) // $ 표시 (DOM 요소에 전달x)
+ * @param {number} [props.$height] - 계산된 height (px)
+ * @param {number | string} [props.$left] - 계산된 left 위치 (%, px 등)
+ * @param {number | string} [props.$width] - 계산된 width (%, px 등)
+ */
+export const CalendarEvent = ({ event, $top, $height, $left, $width }) => {
+  const navigate = useNavigate();
+
+  const handleClick = (e) => {
+    e.stopPropagation(); // 이벤트 버블링 방지
+    logger.info(`Navigating to event detail: ${event.id}`);
+    navigate(`/events/${event.id}`);
+  };
+
+  // 위치 정보가 유효한지 확인
+  if (
+    $top === undefined ||
+    $height === undefined ||
+    $left === undefined ||
+    $width === undefined
+  ) {
+    logger.warn(
+      `Event ID ${event.id}에 유효하지 않은 위치 props가 전달되었습니다`
+    );
+    return null;
+  }
+
+  return (
+    <EventWrapper
+      onClick={handleClick}
+      $top={$top}
+      $height={$height}
+      $left={$left}
+      $width={$width}
+      title={event.title}
+      aria-label={`이벤트: ${event.title}`}
+    >
+      <EventContent>{event.title || "제목 없음"}</EventContent>
+    </EventWrapper>
+  );
+};

--- a/src/features/calendar/components/CalendarGrid/CalendarGrid.jsx
+++ b/src/features/calendar/components/CalendarGrid/CalendarGrid.jsx
@@ -1,0 +1,242 @@
+import { ErrorMessage } from "@common/components";
+import { Err, isErr, logger, Ok } from "@common/utils";
+import {
+  AXIS_WIDTH,
+  DATE_AXIS_HEIGHT,
+  HOUR_HEIGHT,
+  HOURS_IN_DAY,
+  TOTAL_CALENDAR_HEIGHT,
+  USER_TIME_ZONE,
+} from "@features/calendar/constants/calendarConstants";
+import {
+  eachDayOfInterval,
+  endOfWeek,
+  isSameDay,
+  isValid,
+  parseISO,
+  startOfWeek,
+} from "date-fns";
+import { toZonedTime } from "date-fns-tz";
+import styled from "styled-components";
+import { DateAxis } from "./DateAxis";
+import { EventLane } from "./EventLane";
+import { TimeAxis } from "./TimeAxis";
+
+// 전체 Grid 컨테이너
+const GridContainer = styled.div`
+  flex-grow: 1;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  background-color: #fff;
+  border-top: 1px solid #e0e0e0;
+`;
+
+// 날짜 축 영역
+const DateAxisArea = styled.div`
+  display: flex;
+  flex-shrink: 0; // 높이 고정
+`;
+
+// 시간 축 위 빈 공간
+const TimeAxisGap = styled.div`
+  width: ${AXIS_WIDTH}px;
+  flex-shrink: 0;
+  height: ${DATE_AXIS_HEIGHT}px;
+  border-bottom: 1px solid #e0e0e0;
+  background-color: #fff;
+`;
+
+// 스크롤이 적용될 메인 컨텐츠 영역 (TimeAxis + ContentArea)
+const ScrollableContent = styled.div`
+  flex-grow: 1;
+  display: flex; // TimeAxis 와 Content 를 가로로 배치
+  overflow-y: scroll; // 세로 스크롤
+`;
+
+// 이벤트 내용 영역
+const ContentArea = styled.div`
+  flex-grow: 1;
+  display: flex; // 여러 EventLane을 가로로 배치
+  position: relative;
+  border-left: 1px solid #e0e0e0;
+  min-height: ${TOTAL_CALENDAR_HEIGHT}px;
+`;
+
+// 시간 구분선 컨테이너 (ContentArea 위에 겹쳐짐)
+const TimeLines = styled.div`
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  pointer-events: none; // 이벤트 클릭 방해하지 않도록 설정
+  display: flex; // 내부 라인 정렬
+`;
+
+const TimeLineColumn = styled.div`
+  flex: 1; // 각 날짜 열 너비만큼 차지
+  height: 100%;
+`;
+// 개별 시간 구분선
+const TimeLine = styled.div`
+  height: ${HOUR_HEIGHT}px;
+  border-bottom: 1px solid #eee;
+  border-left: 1px solid #eee;
+
+  &:first-child {
+    border-top: 1px solid #eee; // 맨 위에도 선 추가
+  }
+`;
+
+const FirstTimeLineColumn = styled(TimeLineColumn)`
+  ${TimeLine} {
+    border-left: none;
+  }
+`;
+
+/**
+ * 주어진 날짜가 속한 주의 모든 날짜 배열을 반환
+ * @param {Date} date
+ * @returns {Date[]}
+ */
+const getWeekDays = (date) => {
+  try {
+    const start = startOfWeek(date);
+    const end = endOfWeek(date);
+    return Ok(eachDayOfInterval({ start, end }));
+  } catch (error) {
+    logger.error("Error claculating week days:", error);
+    return Err(new Error("Failed to calculate week days"));
+  }
+};
+
+/**
+ * 특정 날짜에 해당하는 이벤트들을 필터링 (KST 기준)
+ * @param {Array} allEvents - 전체 이벤트 목록
+ * @param {Date} targetDate - 필터링 기준 날짜 (Date 객체)
+ * @returns {Array} 필터링 된 이벤트 목록
+ */
+const filterEventsForDate = (allEvents, targetDate) => {
+  if (!allEvents || !Array.isArray(allEvents)) {
+    logger.warn("[filterEventsForDate] Invalid allEvents received:", allEvents);
+    return []; // 유효하지 않은 이벤트 목록 처리
+  }
+  if (!isValid(targetDate)) {
+    logger.warn(
+      "[filterEventsForDate] Invalid targetDate received:",
+      targetDate
+    );
+    return []; // 유효하지 않은 날짜 객체 처리
+  }
+
+  return allEvents.filter((event) => {
+    // event 객체 및 start_time 검사
+    if (
+      !event ||
+      typeof event !== "object" ||
+      typeof event.start_time !== "string"
+    ) {
+      logger.warn(
+        `[filterEventsForDate] Skipping invalid event object or missing start_time:`,
+        event
+      );
+      return false;
+    }
+
+    try {
+      // 1. DB에서 온 UTC ISO 문자열 파싱
+      const startUtc = parseISO(event.start_time);
+
+      if (!isValid(startUtc)) {
+        logger.warn(
+          `[filterEventsForDate] Failed to parse start_time for event ID ${event.id}: ${event.start_time}`
+        );
+        return false;
+      }
+
+      // 2. UTC Date 객체를 KST 시간으로 변환
+      const startKST = toZonedTime(startUtc, USER_TIME_ZONE);
+
+      // 3. KST 기준 이벤트 시작 날짜와 targetDate 비교
+      const result = isSameDay(startKST, targetDate);
+
+      return result;
+    } catch (error) {
+      logger.warn(
+        `[filterEventsForDate] Error processing event time for filtering (ID: ${event.id}):`,
+        error
+      );
+      return false;
+    }
+  });
+};
+
+/**
+ * Calendar Grid Component: 시간/날짜 축 및 이벤트 표시 영역 레이아웃
+ * @param {object} props
+ * @param {Date} props.currentDate - 현재 표시 날짜
+ * @param {Array} props.events - 표시할 이벤트 목록
+ * @param {"day" | "week"} props.viewMode - 보기 모드 ("day" 또는 "week")
+ */
+export const CalendarGrid = ({ currentDate, events, viewMode }) => {
+  logger.debug("CalendarGrid 렌더링", { viewMode, eventCount: events.length });
+  const hours = HOURS_IN_DAY;
+
+  const displayDatesResult =
+    viewMode === "week" ? getWeekDays(currentDate) : Ok([currentDate]);
+
+  let displayDates = [];
+  if (isErr(displayDatesResult)) {
+    logger.error("Failed to get displat dates:", displayDatesResult.error);
+    return <ErrorMessage message={"날짜 정보를 표시할 수 없습니다."} />;
+  } else {
+    displayDates = displayDatesResult.value;
+  }
+
+  return (
+    <GridContainer>
+      {/* 상단: 날짜 축 영역 */}
+      <DateAxisArea>
+        <TimeAxisGap />
+        <DateAxis
+          currentDate={currentDate}
+          viewMode={viewMode}
+          displayDates={displayDates}
+        />
+      </DateAxisArea>
+
+      {/* 하단: 스크롤 가능한 컨텐츠 영역 */}
+      <ScrollableContent>
+        {/* 왼쪽: 시간 축 */}
+        <TimeAxis />
+
+        {/* 오른쪽: 이벤트 내용 */}
+        <ContentArea>
+          <TimeLines>
+            {displayDates.map((date, index) => {
+              const ColumnComponent =
+                index === 0 ? FirstTimeLineColumn : TimeLineColumn;
+              return (
+                <ColumnComponent key={date.toISOString()}>
+                  {hours.map((hour) => (
+                    <TimeLine key={hour} />
+                  ))}
+                </ColumnComponent>
+              );
+            })}
+          </TimeLines>
+
+          {displayDates.map((date) => (
+            <EventLane
+              key={date.toISOString()}
+              specificDate={date}
+              events={filterEventsForDate(events, date)}
+              viewMode={viewMode}
+            />
+          ))}
+        </ContentArea>
+      </ScrollableContent>
+    </GridContainer>
+  );
+};

--- a/src/features/calendar/components/CalendarGrid/DateAxis.jsx
+++ b/src/features/calendar/components/CalendarGrid/DateAxis.jsx
@@ -1,0 +1,78 @@
+import { logger } from "@common/utils";
+import { DATE_AXIS_HEIGHT } from "@features/calendar/constants/calendarConstants";
+import { DATE_FORMAT_AXIS_DAY } from "@features/calendar/constants/dateFormats";
+import { format, isToday, isValid } from "date-fns";
+import { ko } from "date-fns/locale";
+import styled, { css } from "styled-components";
+
+// 날짜 축 컨테이너
+const AxisContainer = styled.div`
+  display: flex;
+  flex-grow: 1;
+  border-bottom: 1px solid #e0e0e0;
+  background-color: #fff;
+  flex-shrink: 0; // 높이 고정
+  height: ${DATE_AXIS_HEIGHT}px;
+  align-items: center;
+`;
+
+// 각 날짜 헤더
+const DateHeader = styled.div`
+  flex: 1; // 모든 날짜 헤더가 동일 너비 차지
+  padding: 0 5px;
+  text-align: center;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #333;
+
+  // 오늘 날짜 강조
+  ${(props) =>
+    props.$isToday &&
+    css`
+      color: #1a73e8;
+      font-weight: bold;
+    `}
+`;
+
+/**
+ * Date Axis Component
+ * @param {object} props
+ * @param {Date[]} props.displayDates - 표시할 날짜 배열
+ */
+export const DateAxis = ({ displayDates = [] }) => {
+  if (!Array.isArray(displayDates)) {
+    logger.warn(
+      "DateAxis: Invalid displayDates props received (not array).",
+      displayDates
+    );
+    return null;
+  }
+
+  const allDatesValid = displayDates.every(isValid);
+  if (!allDatesValid) {
+    logger.error(
+      "DateAxis: contains invalid date(s) in displayDayes array.",
+      displayDates
+    );
+    return null;
+  }
+
+  if (displayDates.length === 0) {
+    logger.warn("DateAxis: displayDates array is empty.");
+    return <AxisContainer />;
+  }
+
+  return (
+    <AxisContainer>
+      {displayDates.map((date) => {
+        const dateKey = date.toISOString();
+        return (
+          <DateHeader key={dateKey} $isToday={isToday(date)}>
+            {/* 예시: "15 (화)" */}
+            {format(date, DATE_FORMAT_AXIS_DAY, { locale: ko })}
+          </DateHeader>
+        );
+      })}
+    </AxisContainer>
+  );
+};

--- a/src/features/calendar/components/CalendarGrid/EventLane.jsx
+++ b/src/features/calendar/components/CalendarGrid/EventLane.jsx
@@ -1,0 +1,114 @@
+import { isErr, logger } from "@common/utils";
+import {
+  DAY_VIEW_EVENT_LEFT,
+  DAY_VIEW_EVENT_WIDTH
+} from "@features/calendar/constants/calendarConstants";
+import {
+  calculateEventPosition,
+  calculateHorizontalLayout,
+} from "@features/calendar/utils/eventLayoutUtils";
+import { compareAsc, parseISO } from "date-fns";
+import styled from "styled-components";
+import { CalendarEvent } from "./CalendarEvent";
+import { useMemo } from "react";
+
+const LaneContainer = styled.div`
+  position: relative;
+  flex: 1;
+  min-height: 100%;
+  border-left: 1px solid #eee; // week 뷰에서 날짜 구분 선 역할
+
+  &:first-child {
+    border-left: none; // 첫 번째 레인 왼쪽 테두리는 제거
+  }
+`;
+
+export const EventLane = ({ specificDate, events, viewMode }) => {
+  logger.debug(`EventLane 렌더링 for ${viewMode} view`, {
+    eventCount: events.length,
+    date: specificDate,
+  });
+
+  // --- 레이아웃 계산 로직 ---
+  const eventsWithLayout = useMemo(() => {
+    // 이벤트 정렬
+    const sortedEvents = events.toSorted((a, b) => {
+      try {
+        const startComparison = compareAsc(
+          parseISO(a.start_time),
+          parseISO(b.start_time)
+        );
+        if (startComparison !== 0) {
+          return startComparison;
+        }
+        return compareAsc(parseISO(a.end_time), parseISO(b.end_time));
+      } catch (error) {
+        logger.warn("Error sorting evnets:", error, a, b);
+        return 0;
+      }
+    });
+
+    // 가로 레이아웃 계산
+    const horizontalLayoutResult = calculateHorizontalLayout(sortedEvents);
+
+    if (isErr(horizontalLayoutResult)) {
+      logger.error(
+        "Failed to calculate horizontal layout",
+        horizontalLayoutResult.error
+      );
+      // 에러 발생 시, 기본 레이아웃으로 처리
+      return sortedEvents.map((event) => ({
+        ...event,
+        layout: { left: DAY_VIEW_EVENT_LEFT, width: DAY_VIEW_EVENT_WIDTH },
+      }));
+    }
+
+    const eventsWithHorizontalLayout = horizontalLayoutResult.value;
+
+    // 세로 위치(top, height) 계산 및 최종 데이터 조합
+    return eventsWithHorizontalLayout
+      .map((eventData) => {
+        const positionResult = calculateEventPosition(eventData);
+
+        if (isErr(positionResult)) {
+          logger.error(
+            `Event ID ${eventData.id} 세로 위치 계산 실패:`,
+            positionResult.error
+          );
+          return null;
+        }
+
+        const { top, height } = positionResult.value;
+
+        // 렌더링에 필요한 모든 정보 결합
+        return {
+          ...eventData,
+          renderData: {
+            top,
+            height,
+            left: eventData.layout.left,
+            width: eventData.layout.width,
+          },
+        };
+      })
+      .filter(Boolean); // 계산 실패(null) 이벤트 제거
+  }, [events]);
+
+  // --- 렌더링 로직 ---
+  const renderEvents = () => {
+    return eventsWithLayout.map((eventData) => {
+      return (
+        <CalendarEvent
+          key={eventData.id}
+          event={eventData}
+          $top={eventData.renderData.top}
+          $height={eventData.renderData.height}
+          $left={eventData.renderData.left}
+          $width={eventData.renderData.width}
+        />
+      );
+    });
+  };
+
+  return <LaneContainer>{renderEvents()}</LaneContainer>;
+};

--- a/src/features/calendar/components/CalendarGrid/TimeAxis.jsx
+++ b/src/features/calendar/components/CalendarGrid/TimeAxis.jsx
@@ -1,0 +1,45 @@
+import {
+  AXIS_WIDTH,
+  HOUR_HEIGHT,
+  HOURS_IN_DAY,
+  TOTAL_CALENDAR_HEIGHT,
+} from "@features/calendar/constants/calendarConstants";
+import styled from "styled-components";
+
+const AxisContainer = styled.div`
+  width: ${AXIS_WIDTH}px;
+  flex-shrink: 0;
+  position: relative; // span 위치 조정을 위해
+  background-color: #f8f9fa;
+  min-height: ${TOTAL_CALENDAR_HEIGHT}px;
+`;
+
+const TimeSlot = styled.div`
+  height: ${HOUR_HEIGHT}px;
+  position: relative;
+  text-align: right;
+  padding-right: 8px;
+  font-size: 0.75rem;
+  color: #6c757d;
+
+  /* 시간 텍스트 */
+  & > span {
+    position: absolute;
+    top: -8px; // 선과 겹치지 않도록 살짝 위로
+    right: 8px;
+    background-color: #f8f9fa; // 아래 선 가리기 위한 배경색
+    padding: 0 2px; // 좌우 약간 여백
+  }
+`;
+
+export const TimeAxis = () => {
+  return (
+    <AxisContainer>
+      {HOURS_IN_DAY.map((hour) => (
+        <TimeSlot key={hour}>
+          {hour > 0 && <span>{`${hour.toString().padStart(2, "0")}:00`}</span>}
+        </TimeSlot>
+      ))}
+    </AxisContainer>
+  );
+};

--- a/src/features/calendar/components/CalendarGrid/index.js
+++ b/src/features/calendar/components/CalendarGrid/index.js
@@ -1,0 +1,1 @@
+export { CalendarGrid } from "./CalendarGrid";

--- a/src/features/calendar/components/CalendarHeader.jsx
+++ b/src/features/calendar/components/CalendarHeader.jsx
@@ -1,0 +1,173 @@
+import { logger } from "@common/utils";
+import { endOfWeek, format, isValid, startOfWeek } from "date-fns";
+import { ko } from "date-fns/locale";
+import { useMemo } from "react";
+import styled, { css } from "styled-components";
+import {
+  DATE_FORMAT_DAY_ONLY,
+  DATE_FORMAT_DAY_WITH_SUFFIX,
+  DATE_FORMAT_MONTH_DAY,
+  DATE_FORMAT_YEAR_MONTH_DAY,
+} from "../constants/dateFormats";
+
+const HeaderContainer = styled.div`
+  padding: 15px 20px;
+  display: flex;
+  align-items: center;
+  border-bottom: 1px solid #e0e0e0;
+  background-color: #fff;
+  flex-shrink: 0;
+`;
+
+const ButtonGroup = styled.div`
+  display: flex;
+  gap: 10px;
+  flex: 1;
+  justify-content: flex-start;
+`;
+const Button = styled.button`
+  padding: 8px 12px;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+  cursor: pointer;
+  font-size: 0.9rem;
+  transition: background-color 0.2s ease;
+  background-color: #fff;
+
+  &:hover {
+    background-color: #f8f9fa;
+  }
+
+  &:active {
+    background-color: #e9ecef;
+  }
+
+  // 활성 스타일
+  ${(props) =>
+    props.$active &&
+    css`
+      background-color: #e9ecef;
+      border-color: #adb5bd;
+      font-weight: bold;
+    `}
+`;
+
+const CurrentDateText = styled.h2`
+  font-size: 1.3rem;
+  font-weight: 500;
+  margin: 0 20px;
+  text-align: center;
+`;
+
+const RightSection = styled.div`
+  flex: 1;
+  display: flex;
+  justify-content: flex-end;
+`;
+
+/**
+ * Calendar Header Component
+ * @param {object} props
+ * @param {Date} props.currentDate - 현재 표시 날짜 Date 객체
+ * @param {()=>void} props.onPrev - 이전 기간 이동 함수
+ * @param {()=>void} props.onNext - 다음 기간 이동 함수
+ * @param {()=>void} props.onGoToToday - 오늘 날짜 이동 함수
+ * @param {(mode: "day" | "week")=>void} props.onSetViewMode - 뷰 모드 변경 함수
+ */
+export const CalendarHeader = ({
+  currentDate,
+  viewMode,
+  onPrev,
+  onNext,
+  onGoToToday,
+  onSetViewMode,
+}) => {
+  // 날짜 포맷팅
+  const formattedDate = useMemo(() => {
+    if (!currentDate || !isValid(currentDate)) {
+      logger.warn(
+        "Invalid currentDate prop received in CalendarHeader:",
+        currentDate
+      );
+      return "날짜 정보 없음";
+    }
+    try {
+      if (viewMode === "day") {
+        // "yyyy년 M월 d일 (EEE)"
+        return format(
+          currentDate,
+          `${DATE_FORMAT_YEAR_MONTH_DAY} ${DATE_FORMAT_DAY_WITH_SUFFIX}`,
+          { locale: ko }
+        );
+      } else {
+        // viewMode === "week"
+        const start = startOfWeek(currentDate);
+        const end = endOfWeek(currentDate);
+        const startFormatted = format(start, DATE_FORMAT_YEAR_MONTH_DAY, {
+          locale: ko,
+        });
+        // 월이 같으면 "yyyy년 M월 d일 - d일", 다르면 "yyyy년 M월 d일 - M월 d일"
+        if (start.getMonth() === end.getMonth()) {
+          const endFormatted = format(end, DATE_FORMAT_DAY_ONLY, {
+            locale: ko,
+          });
+          return `${startFormatted} - ${endFormatted}`;
+        } else {
+          const endFormatted = format(end, DATE_FORMAT_MONTH_DAY, {
+            locale: ko,
+          });
+          return `${startFormatted} - ${endFormatted}`;
+        }
+      }
+    } catch (error) {
+      logger.error(
+        "Error formatting date in CalendarHeader:",
+        error,
+        currentDate,
+        viewMode
+      );
+      return "날짜 표시 오류";
+    }
+  }, [currentDate, viewMode]);
+
+  return (
+    <HeaderContainer>
+      <ButtonGroup>
+        <Button onClick={onGoToToday} aria-label="오늘 날짜로 이동">
+          오늘
+        </Button>
+        <Button
+          onClick={onPrev}
+          aria-label={viewMode === "day" ? "이전 날짜" : "이전 주"}
+        >
+          &lt;
+        </Button>
+        <Button
+          onClick={onNext}
+          aria-label={viewMode === "day" ? "다음 날짜" : "다음 주"}
+        >
+          &gt;
+        </Button>
+      </ButtonGroup>
+
+      <CurrentDateText>{formattedDate}</CurrentDateText>
+
+      <RightSection>
+        <Button
+          onClick={() => onSetViewMode("day")}
+          $active={viewMode === "day"}
+          aria-pressed={viewMode === "day"}
+        >
+          일간
+        </Button>
+        <Button
+          onClick={() => onSetViewMode("week")}
+          $active={viewMode === "week"}
+          aria-pressed={viewMode === "week"}
+        >
+          주간
+        </Button>
+      </RightSection>
+    </HeaderContainer>
+  );
+};

--- a/src/features/calendar/constants/calendarConstants.js
+++ b/src/features/calendar/constants/calendarConstants.js
@@ -1,0 +1,10 @@
+export const HOURS_IN_DAY = Array.from({ length: 24 }, (_, i) => i); // 0부터 23
+export const HOUR_HEIGHT = 50; // 시간 슬롯 높이 (px)
+export const AXIS_WIDTH = 60; // 시간 축 너비 (px)
+export const DATE_AXIS_HEIGHT = 30; // 날짜 축 높이 (px)
+export const TOTAL_CALENDAR_HEIGHT = HOUR_HEIGHT * HOURS_IN_DAY.length;
+
+export const USER_TIME_ZONE = "Asia/Seoul";
+
+export const DAY_VIEW_EVENT_LEFT = '5%';
+export const DAY_VIEW_EVENT_WIDTH = '90%';

--- a/src/features/calendar/constants/dateFormats.js
+++ b/src/features/calendar/constants/dateFormats.js
@@ -1,0 +1,6 @@
+export const DATE_FORMAT_YEAR_MONTH_DAY = "yyyy년 M월 d일";
+export const DATE_FORMAT_DAY_ONLY = "d일";
+export const DATE_FORMAT_MONTH_DAY = "M월 d일";
+export const DATE_FORMAT_DAY_WITH_SUFFIX = "(EEE)";
+
+export const DATE_FORMAT_AXIS_DAY = "d (EEE)"; // 날짜 축 표시용

--- a/src/features/calendar/hooks/useCalendarNavigation.js
+++ b/src/features/calendar/hooks/useCalendarNavigation.js
@@ -1,0 +1,60 @@
+import { addDays, addWeeks, subDays, subWeeks } from "date-fns";
+import { useCallback, useState } from "react";
+
+/**
+ * 캘린더 네비게이션 및 뷰 모드 상태 관리 훅
+ * @param {Date} [initialDate=new Date()] - 초기 날짜
+ * @param {"day" | "week"} [initialViewMode="day"] - 초기 뷰 모드
+ * @returns {{
+ * currentDate: Date,
+ * viewMode: "day" | "week",
+ * setViewMode: (mode: "day" | "week") => void,
+ * goToNext: () => void,
+ * goToPrev: () => void,
+ * goToToday: () => void,
+ * }}
+ */
+export const useCalendarNavigation = (
+  initialDate = new Date(),
+  initialViewMode = "day"
+) => {
+  const [currentDate, setCurrentDate] = useState(initialDate);
+  const [viewMode, setViewModeState] = useState(initialViewMode);
+
+  const setViewMode = useCallback((mode) => {
+    if (mode === "day" || mode === "week") {
+      setViewModeState(mode);
+    }
+  }, []);
+
+  const goToNext = useCallback(() => {
+    if (viewMode === "day") {
+      setCurrentDate((current) => addDays(current, 1));
+    } else {
+      // viewMode === "week"
+      setCurrentDate((current) => addWeeks(current, 1));
+    }
+  }, [viewMode]);
+
+  const goToPrev = useCallback(() => {
+    if (viewMode === "day") {
+      setCurrentDate((current) => subDays(current, 1));
+    } else {
+      setCurrentDate((current) => subWeeks(current, 1));
+    }
+  }, [viewMode]);
+
+  const goToToday = useCallback(() => {
+    setCurrentDate(new Date());
+    setViewModeState("day");
+  }, []);
+
+  return {
+    currentDate,
+    viewMode,
+    setViewMode,
+    goToNext,
+    goToPrev,
+    goToToday,
+  };
+};

--- a/src/features/calendar/index.js
+++ b/src/features/calendar/index.js
@@ -1,0 +1,3 @@
+export { CalendarGrid } from "./components/CalendarGrid";
+export { CalendarHeader } from "./components/CalendarHeader";
+export { useCalendarNavigation } from "./hooks/useCalendarNavigation";

--- a/src/features/calendar/utils/eventLayoutUtils.js
+++ b/src/features/calendar/utils/eventLayoutUtils.js
@@ -1,0 +1,215 @@
+import { Err, logger, Ok } from "@common/utils";
+import {
+  HOUR_HEIGHT,
+  USER_TIME_ZONE,
+} from "@features/calendar/constants/calendarConstants";
+import {
+  differenceInHours,
+  getHours,
+  isAfter,
+  isBefore,
+  isValid,
+  parseISO,
+} from "date-fns";
+import { toZonedTime } from "date-fns-tz";
+
+/**
+ * 이벤트 객체를 받아 캘린더 그리드 상의 위치(top)와 높이(height)를 계산합니다.
+ * 계산 성공 시 Ok({top, height}), 실패 시 Err(error)를 반환합니다.
+ *
+ * @param {object} event - 이벤트 객체 (start_time, end_time 포함)
+ * @returns {Result<{top: number, height: number}, Error>} 계산 결과 또는 에러
+ */
+export const calculateEventPosition = (event) => {
+  try {
+    if (!event || typeof event !== "object") {
+      return Err(new Error("Invalid event object provided."));
+    }
+    if (!event.start_time || typeof event.start_time !== "string") {
+      return Err(new Error("Invalid or missing start_time string."));
+    }
+    if (!event.end_time || typeof event.end_time !== "string") {
+      return Err(new Error("Invalid or missing end_time string."));
+    }
+
+    // 2. UTC 시간 문자열을 Date 객체로 파싱
+    const startUtc = parseISO(event.start_time);
+    const endUtc = parseISO(event.end_time);
+
+    // 파싱된 Date 객체 유효성 검사
+    if (!isValid(startUtc)) {
+      return Err(new Error(`Failed to parse start_time: ${event.start_time}`));
+    }
+    if (!isValid(endUtc)) {
+      return Err(new Error(`Failed to parse end_time: ${event.end_time}`));
+    }
+
+    // 3. UTC Date 객체를 사용자 시간대(KST) 기준으로 변환
+    const startKST = toZonedTime(startUtc, USER_TIME_ZONE);
+    const endKST = toZonedTime(endUtc, USER_TIME_ZONE);
+
+    // 4. KST 기준 시작 시간(hour)으로 top 위치 계산
+    const startHourKST = getHours(startKST);
+    const top = startHourKST * HOUR_HEIGHT;
+
+    // 5. KST 기준 시작 시간과 종료 시간의 시간(hour) 차이로 height 계산
+    const durationInHours = differenceInHours(endKST, startKST);
+
+    // duration이 0 또는 음수인 경우 에러 처리
+    if (durationInHours <= 0) {
+      // 종료 시간이 시작 시간보다 같거나 이전인 경우
+      return Err(
+        new Error(
+          `Invalid event duration: start=${event.start_time}, end=${event.end_time}. Duration must be at least 1 hour.`
+        )
+      );
+    }
+    const height = durationInHours * HOUR_HEIGHT;
+
+    // 성공 시
+    return Ok({ top, height });
+  } catch (error) {
+    logger.error(
+      `calculateEventPosition unexpected error (Event ID: ${event?.id}):`,
+      error
+    );
+    // 예상치 못한 에러 발생 시 Err 객체 반환
+    return Err(
+      error instanceof Error ? error : new Error("Unknown calculation error")
+    );
+  }
+};
+
+/**
+ * 시간 슬롯 기반으로 이벤트 목록의 가로 레이아웃(left, width)을 계산합니다.
+ * (요구사항: 이벤트는 1시간 단위 정시 시작/종료)
+ * @param {Array} sortedEvents - 시작 시간 기준으로 정렬된 이벤트 목록
+ * @param {number} [totalWidthPercent=100] - 사용 가능한 전체 너비 비율
+ * @param {number} [eventGapPercent=1] - 이벤트 사이의 간격 비율
+ * @returns {Result <Array, Error>} 각 이벤트에 {...object, layout: {left: string, width: string}} 객체가 추가된 배열 또는 에러
+ */
+export const calculateHorizontalLayout = (
+  sortedEvents,
+  totalWidthPercent = 100,
+  eventGapPercent = 1
+) => {
+  if (!Array.isArray(sortedEvents)) {
+    return Err(new Error("Invalid input: sortedEvents must be an array."));
+  }
+  if (sortedEvents.length === 0) {
+    return Ok([]);
+  }
+
+  try {
+    // --- 1. 초기화 및 데이터 변환 ---
+    const timeSlots = Array.from({ length: 24 }, () => ({
+      eventIds: new Set(), // 각 슬롯에 포함될 이벤트 ID 를 Set 으로 관리 (중복 제거, 빠른 조회)
+    }));
+    const layoutInfo = []; // 각 아이템을 { evnet, startTime, endTime, layout } 형식으로 저장
+
+    // 이후 작업을 위한 이벤트 데이터 파싱 및 layoutInfo 초기화
+    for (const [index, event] of sortedEvents.entries()) {
+      if (
+        !event ||
+        typeof event !== "object" ||
+        !event.start_time ||
+        !event.end_time
+      ) {
+        return Err(new Error(`Invalid evnet object at index ${index}`));
+      }
+      const startTime = parseISO(event.start_time);
+      const endTime = parseISO(event.end_time);
+      if (!isValid(startTime) || !isValid(endTime)) {
+        return Err(
+          new Error(
+            `Invalid start or end time for event ID ${event.id || index}`
+          )
+        );
+      }
+      layoutInfo.push({
+        event,
+        startTime,
+        endTime,
+        layout: { left: 0, width: 100, maxOverlap: 1, columnIndex: -1 },
+      });
+
+      // 시간 슬롯에 이벤트 ID 기록
+      const startHour = getHours(startTime);
+      const endHour = getHours(endTime);
+      for (let hour = startHour; hour < endHour; hour += 1) {
+        if (hour >= 0 && hour < 24) {
+          timeSlots[hour].eventIds.add(event.id);
+        } else {
+          logger.warn(`Event ${event.id} has invalid hour range: ${hour}`);
+        }
+      }
+    }
+
+    // --- 2. 각 이벤트의 최대 동시 겹침 수 계산 ---
+    layoutInfo.forEach((info) => {
+      let maxOverlapForEvent = 1;
+      const startHour = getHours(info.startTime);
+      const endHour = getHours(info.endTime);
+
+      for (let hour = startHour; hour < endHour; hour += 1) {
+        if (hour >= 0 && hour < 24) {
+          maxOverlapForEvent = Math.max(
+            maxOverlapForEvent,
+            timeSlots[hour].eventIds.size
+          );
+        }
+      }
+
+      info.layout.maxOverlap = maxOverlapForEvent;
+    });
+
+    // --- 3. 컬럼 할당 로직 ---
+    const columnsEndTime = []; // 각 컬럼의 마지막 이벤트 종료시간을 저장
+    for (let i = 0; i < layoutInfo.length; i += 1) {
+      const currentEventInfo = layoutInfo[i];
+      let placedColumnIndex = -1;
+
+      for (let colIndex = 0; colIndex < columnsEndTime.length; colIndex += 1) {
+        // 기존 컬럼에 배치 가능한지 확인
+        if (!isBefore(currentEventInfo.startTime, columnsEndTime[colIndex])) {
+          placedColumnIndex = colIndex;
+          break;
+        }
+      }
+
+      if (placedColumnIndex !== -1) {
+        // 배치 가능한 컬럼이 있다면
+        currentEventInfo.layout.columnIndex = placedColumnIndex;
+        if (
+          isAfter(currentEventInfo.endTime, columnsEndTime[placedColumnIndex])
+        ) {
+          columnsEndTime[placedColumnIndex] = currentEventInfo.endTime; // 종료 시간 갱신
+        }
+      } else {
+        currentEventInfo.layout.columnIndex = columnsEndTime.length;
+        columnsEndTime.push(currentEventInfo.endTime);
+      }
+    }
+
+    // --- 4. left, width 계산 ---
+    const results = layoutInfo.map((info) => {
+      const { event, layout } = info;
+      const { columnIndex, maxOverlap } = layout;
+
+      const width =
+        (totalWidthPercent - (maxOverlap - 1) * eventGapPercent) / maxOverlap;
+      const left = columnIndex * (width + eventGapPercent);
+
+      return { ...event, layout: { left: `${left}%`, width: `${width}%` } };
+    });
+
+    return Ok(results);
+  } catch (error) {
+    logger.error("Error calculating horizontal layout:", error);
+    return Err(
+      error instanceof Error
+        ? error
+        : new Error("Unknown layout calculation error")
+    );
+  }
+};

--- a/src/pages/CalendarPage.jsx
+++ b/src/pages/CalendarPage.jsx
@@ -1,5 +1,85 @@
+import { STATUS } from "@common/constants";
+import { logger } from "@common/utils";
+import {
+  CalendarGrid,
+  CalendarHeader,
+  useCalendarNavigation,
+} from "@features/calendar";
+import { fetchEvents } from "@features/events";
+import { useEffect } from "react";
+import { useDispatch, useSelector } from "react-redux";
+import styled from "styled-components";
+
+const CalendarContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  height: 100vh;
+  overflow: hidden;
+`;
+
+// 로딩 및 에러 컴포넌트 (임시)
+const LoadingSpinner = styled.div`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  height: 100%;
+`;
+const ErrorMessageContainer = styled.div`
+  padding: 20px;
+  color: red;
+  text-align: center;
+`;
+
 const CalendarPage = () => {
-  return <h1>Calendar Page</h1>;
+  const dispatch = useDispatch();
+  const entities = useSelector((state) => state.events.entities);
+  const status = useSelector((state) => state.events.status);
+  const error = useSelector((state) => state.events.error);
+
+  const { currentDate, goToNext, goToPrev, goToToday, viewMode, setViewMode } =
+    useCalendarNavigation();
+
+  useEffect(() => {
+    if (status === STATUS.IDLE) {
+      // 최초 로드 또는 상태 초기화 시에만 호출
+      logger.info("Fetching events (CalendarPage mount/update)");
+      dispatch(fetchEvents());
+    }
+  }, [status]);
+
+  if (status === STATUS.LOADING && Object.keys(entities).length === 0) {
+    logger.info("CalendarPage: Displaying loading spinner");
+    return <LoadingSpinner>캘린더 로딩 중...</LoadingSpinner>;
+  }
+
+  if (status === STATUS.FAILED && error) {
+    logger.error("CalendarPage: Displaying error message:", error);
+    return (
+      <ErrorMessageContainer>
+        이벤트 중 오류가 발생했습니다: {error}
+      </ErrorMessageContainer>
+    );
+  }
+
+  const allEvents = Object.values(entities);
+
+  return (
+    <CalendarContainer>
+      <CalendarHeader
+        currentDate={currentDate}
+        viewMode={viewMode}
+        onPrev={goToPrev}
+        onNext={goToNext}
+        onGoToToday={goToToday}
+        onSetViewMode={setViewMode}
+      />
+      <CalendarGrid
+        currentDate={currentDate}
+        events={allEvents}
+        viewMode={viewMode}
+      />
+    </CalendarContainer>
+  );
 };
 
 export default CalendarPage;


### PR DESCRIPTION
## [Feat] calendar view 구현
### 요구명세서 반영 부분
- [O] 현재 날짜에 해당하는 달력이 보여져야 합니다. (일별로 보기)
- [O] 사용자는 일간 스케줄 보기, 주간 스케줄 보기 중 하나를 선택할 수 있어야 합니다.
- [O] 사용자가 일간 스케줄 보기를 선택했을 경우, 현재 날짜에 해당하는 이벤트 정보가 보여져야 합니다.
- [O] 사용자가 주간 스케줄 보기를 선택했을 경우, 현재 날짜가 속한 주에 해당하는 이벤트 정보가 보여져야 합니다.
- [O] 구글 캘린더와 같이 Y축 방향으로는 시간대 정보가 보여져야 합니다.
- [O] 일간 스케줄 보기의 경우, X축 방향으로는 현재 날짜가 보여져야 합니다.
- [O] 주간 스케줄 보기의 경우, X축 방향으로는 현재 주에 해당하는 날짜가 보여져야 합니다.
- [O] 이전 날짜/주 혹은 다음 날짜/주로 이동할 수 있는 버튼이 있어야 합니다.
- [O] 달력에서 이벤트를 클릭했을 경우, 해당 이벤트 상세 페이지(/event/<EVENT_ID>)로 이동해야 합니다. 